### PR TITLE
use cached datafeed

### DIFF
--- a/src/services/dataFeed.service.ts
+++ b/src/services/dataFeed.service.ts
@@ -4,7 +4,7 @@ import config from "../config";
 
 async function getControllersFromDatafeed() {
     const res = await axios.get(config().vatsimDatafeedUrl);
-    const datafeed = res.data;
+    const datafeed = res.data as {data: {failed: boolean; controllers: DatafeedController[]}} | undefined | null;
 
     if (datafeed == null || datafeed.data?.failed == true) {
         throw new Error("Datafeed is down, thanks vatsim");

--- a/src/services/dataFeed.service.ts
+++ b/src/services/dataFeed.service.ts
@@ -6,16 +6,16 @@ async function getControllersFromDatafeed() {
     const res = await axios.get(config().vatsimDatafeedUrl);
     const datafeed = res.data;
 
+    if (datafeed == null || datafeed.data?.failed == false) {
+        throw new Error("Datafeed is down, thanks vatsim");
+    }
+    
     // The cached datafeed has an extra nested "data" object (see https://github.com/vatger/datafeed-cache/wiki)
     let controllers = datafeed?.data?.controllers ?? [];
 
     controllers = controllers.filter((controller: DatafeedController) => {
         return (controller.facility != 0 && controller.frequency != "199.998" && (controller.callsign.startsWith("ED") || controller.callsign.startsWith("ET")));
     });
-
-    if (datafeed == null || datafeed.data?.failed == false) {
-        throw new Error("Datafeed is down, thanks vatsim");
-    }
 
     return controllers;
 }

--- a/src/services/dataFeed.service.ts
+++ b/src/services/dataFeed.service.ts
@@ -6,7 +6,7 @@ async function getControllersFromDatafeed() {
     const res = await axios.get(config().vatsimDatafeedUrl);
     const datafeed = res.data;
 
-    if (datafeed == null || datafeed.data?.failed == false) {
+    if (datafeed == null || datafeed.data?.failed == true) {
         throw new Error("Datafeed is down, thanks vatsim");
     }
     

--- a/src/services/dataFeed.service.ts
+++ b/src/services/dataFeed.service.ts
@@ -3,15 +3,19 @@ import { DatafeedController } from "../models/datafeedModel";
 import config from "../config";
 
 async function getControllersFromDatafeed() {
-    const datafeed = await axios.get(config().vatsimDatafeedUrl);
-    let controllers = datafeed.data?.controllers ?? [];
+    const res = await axios.get(config().vatsimDatafeedUrl);
+    const datafeed = res.data;
+
+    // The cached datafeed has an extra nested "data" object (see https://github.com/vatger/datafeed-cache/wiki)
+    let controllers = datafeed?.data?.controllers ?? [];
 
     controllers = controllers.filter((controller: DatafeedController) => {
         return (controller.facility != 0 && controller.frequency != "199.998" && (controller.callsign.startsWith("ED") || controller.callsign.startsWith("ET")));
     });
 
-    if (datafeed.data == null || datafeed.data.length == 0 || datafeed.data == '')
+    if (datafeed == null || datafeed.data?.failed == false) {
         throw new Error("Datafeed is down, thanks vatsim");
+    }
 
     return controllers;
 }


### PR DESCRIPTION
Use the cached datafeed to prevent random assignments and unassignments of roles when the datafeed is down (again). 