### PR TITLE
Feature/idletime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,8 @@ VATSIM_DATAFEED_URL="https://data.vatsim.net/v3/vatsim-data.json"
 MAPPING_URL="https://raw.githubusercontent.com/vatger/teamspeak-station-bot/main/data/atc_station_mappings.json"
 MAPPING_DOWNLOAD_INTERVAL=
 
+#If Clients online / Max Clients exceeds Value idle timeout is decreased to 30m
+MAX_SERVER_LOAD=0.8,
+REGISTERED_SERVER_GROUP=10,
+
 DEBUG=false

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,14 @@ teamspeak.on("ready", async () => {
             console.error(error);
         }
     }, 1000 * 60 * 60); // 60 Minutes
+
+    setInterval(async () => {
+        try {
+            await ts3Controller.checkServerLoadAndUpdateTimeout();
+        } catch (error: any) {
+            console.error(error);
+        }
+    }, 1000 * 30); // 30 Seconds
 });
 
 teamspeak.on("error", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ interface PrefixBotConfig {
     apiToken: string,
     mappingUrl: string,
     mappingDownloadInterval: number,
+    maxServerLoad: number,
+    registeredServerGroupId: number,
     debug: boolean
   }
 
@@ -31,6 +33,8 @@ export default function config(): PrefixBotConfig {
         apiToken: process.env.API_TOKEN ?? '',
         mappingUrl: process.env.MAPPING_URL ?? '',
         mappingDownloadInterval: Number(process.env.MAPPING_DOWNLOAD_INTERVAL) ?? 5,
+        maxServerLoad: Number(process.env.MAX_SERVER_LOAD) ?? 0.8,
+        registeredServerGroupId: Number(process.env.REGISTERED_SERVER_GROUP) ?? 10,
         debug: Boolean(process.env.DEBUG?.toLowerCase())
 
     };

--- a/src/controllers/ts3.controller.ts
+++ b/src/controllers/ts3.controller.ts
@@ -55,6 +55,11 @@ async function updatePrefixes() {
                 permvalue: 1,
             });
 
+            await createdGroup.addPerm({
+                permname: "i_client_max_idletime",
+                permvalue: 18000,
+            });
+
             LogHelper.logMessage(`Group created: ${serverGroupName}`);
 
             for (const tsDbId of controllerTeamspeakIds) {
@@ -146,8 +151,19 @@ async function removeEmptyServerGroups() {
     }
 }
 
+async function checkServerLoadAndUpdateTimeout(){
+    teamspeak.checkServerLoadAndUpdateTimeout();
+}
+
+async function checkServerFull(){
+    LogHelper.logMessage("Checking if Server almost full -> reduce max idle time")
+
+
+}
+
 export default {
     updatePrefixes,
     forceRemoveAllGroups,
     removeEmptyServerGroups,
+    checkServerLoadAndUpdateTimeout,
 };

--- a/src/services/ts.service.ts
+++ b/src/services/ts.service.ts
@@ -64,9 +64,31 @@ async function removeClientFromServerGroup(client_db_id: string, serverGroup: Te
     }
 }
 
+async function checkServerLoadAndUpdateTimeout()
+{
+    const serverInfo = await teamspeak.serverInfo();
+    const load = serverInfo.virtualserverClientsonline / serverInfo.virtualserverMaxclients;
+    let serverGroup: TeamSpeakServerGroup = await teamspeak.getServerGroupById(config().registeredServerGroupId);
+
+    if(load > config().maxServerLoad)
+    {
+        await teamspeak.serverGroupAddPerm(serverGroup, {
+            permname: "i_channel_subscribe_power",
+            permvalue: 1800,
+        })
+    }
+    else{
+        await teamspeak.serverGroupAddPerm(serverGroup, {
+            permname: "i_channel_subscribe_power",
+            permvalue: 18000,
+        })
+    }
+}
+
 export default {
     getCurrentServerGroups,
     getClientsInServerGroup,
     addClientToServerGroup,
-    removeClientFromServerGroup
+    removeClientFromServerGroup,
+    checkServerLoadAndUpdateTimeout,
 };

--- a/src/services/ts.service.ts
+++ b/src/services/ts.service.ts
@@ -73,13 +73,13 @@ async function checkServerLoadAndUpdateTimeout()
     if(load > config().maxServerLoad)
     {
         await teamspeak.serverGroupAddPerm(serverGroup, {
-            permname: "i_channel_subscribe_power",
+            permname: "i_client_max_idletime",
             permvalue: 1800,
         })
     }
     else{
         await teamspeak.serverGroupAddPerm(serverGroup, {
-            permname: "i_channel_subscribe_power",
+            permname: "i_client_max_idletime",
             permvalue: 18000,
         })
     }


### PR DESCRIPTION
Added new feature:

If clients online about to reach max client limit max_idle_time for registered users is set to 30m. Idle time for online controllers is always set to 5h.